### PR TITLE
Update json.md function naming conventions

### DIFF
--- a/boxlang-language/json.md
+++ b/boxlang-language/json.md
@@ -8,10 +8,10 @@ BoxLang supports native JSON support via several key functions and some member f
 
 ## Serialize
 
-BoxLang gives us the `serializeJSON()` function to convert any piece of data to its JSON representation ([https://cfdocs.org/serializejson](https://cfdocs.org/serializejson))
+BoxLang gives us the `jsonSerialize()` function to convert any piece of data to its JSON representation ([https://cfdocs.org/serializejson](https://cfdocs.org/serializejson))
 
 ```javascript
-serializeJson(
+jsonSerialize(
  var
  [, serializeQueryByColumns = false ]
  [, useSecureJSONPrefix = false ]
@@ -23,7 +23,7 @@ Pass in any complex or simple variable to the `var` argument and JSON will be pr
 
 ```javascript
 person = { name = "Luis Majano", company = "Ortus Solutions", year = 2006};
-writeOutput( serializeJSON( person ) );
+writeOutput( jsonSerialize( person ) );
 ```
 
 You can even use the `toJSON()` member function:
@@ -39,7 +39,7 @@ By default BoxLang will convert the keys in a struct to uppercase in the result 
 
 ```javascript
 person = { name = "Luis Majano", company = "Ortus Solutions", year = 2006};
-writeOutput( serializeJSON( person ) );
+writeOutput( jsonSerialize( person ) );
 
 // Will become
 { "NAME" : "Luis Majano", "COMPANY" : "Ortus Solutions", "YEAR" : 2006 }
@@ -65,15 +65,15 @@ BoxLang may incorrectly serialize some strings if they can be automatically conv
 ```javascript
 myStruct = { "zip"="00123" };
 myStruct.setMetadata( { "zip": "string" } );
-writeOutput( serializeJSON(myStruct) );
+writeOutput( jsonSerialize(myStruct) );
 ```
 
 ## Deserialize
 
-The inverse of serialization is deserialization ([https://cfdocs.org/deserializejson](https://cfdocs.org/deserializejson)). BoxLang gives you the `deserializeJSON()` function that will take a JSON document and produce native BoxLang data structures for you.
+The inverse of serialization is deserialization ([https://cfdocs.org/deserializejson](https://cfdocs.org/deserializejson)). BoxLang gives you the `jsonDeserialize()` function that will take a JSON document and produce native BoxLang data structures for you.
 
 ```javascript
-deserializeJSON(
+jsonDeserialize(
  json
  [, strictMapping = true ]
  [, useCustomSerializer = false ]
@@ -84,18 +84,18 @@ Just pass a JSON document, and off we go with native structs/arrays/dates/string
 
 ```java
 if( isJson( mydata ) ){
-    return deserializeJSON( data );
+    return jsonDeserialize( data );
 }
 
-person = deserializeJSON( '{"company":"Ortus","name":"Mr OrtusMan"}' );
+person = jsonDeserialize( '{"company":"Ortus","name":"Mr OrtusMan"}' );
 writeOutput( person.company );
 ```
 
 This function can also be used as a member function in any string literal:
 
 ```java
-var deserializedData = myjsonString.deserializeJson();
-var data = '[]'.deserializeJson();
+var deserializedData = myjsonString.jsonDeserialize();
+var data = '[]'.jsonDeserialize();
 ```
 
 ## Is this JSON?


### PR DESCRIPTION
box lang uses `jsonDeserialize` and `jsonSerialize` instead of the CFML `DeserializeJSON` and `SerializeJSON`