### PR TITLE
Delete Multi-Line Strings section

### DIFF
--- a/getting-started/overview/syntax-style-guide/README.md
+++ b/getting-started/overview/syntax-style-guide/README.md
@@ -107,24 +107,6 @@ BoxLang can interpret ANYTHING within `#` as an expression. This can be used for
 "#now()# is a bif, and this #12 % 2# is a math expression, and more!"
 ```
 
-## Multi-Line Strings
-
-You can declare multi-line strings by using the `"""` start and end operators.  You can also use any interpolation in between.
-
-```java
-myLargeContent = """
-    Hi,
-
-    How are you today #name#!
-
-    This is a very nice email with merged data!
-
-    Thanks for purchasing #item#!
-"""
-
-mailService.send( myLargeContent )
-```
-
 ## Multi-Variable Assignments
 
 BoxLang supports the concept of multi-variable declaration and assignments by just cascading variables using the `=` operator.


### PR DESCRIPTION
Delete Multi-Line Strings section from docs as the parser currently has no support for it.

https://community.ortussolutions.com/t/multi-line-strings-syntax/10325/7?u=aliaspooryorik