### PR TITLE
Update bx-compat block in example

### DIFF
--- a/getting-started/configuration.md
+++ b/getting-started/configuration.md
@@ -244,8 +244,7 @@ Here is a full reference of the current default `boxlang.json` file:
 		// "compat": {
 		// 	"disabled": false,
 		// 	"settings": {
-		// 		"isLucee": true,
-		// 		"isAdobe": true
+		// 		"engine" : "adobe"
 		// 	}
 		// }
 	}


### PR DESCRIPTION
bx-compat now uses `"engine" : "adobe|lucee"` 
the example further down the page is correct