### PR TITLE
Fixed CFM to BXM reference and bx:query to cfquery reference

### DIFF
--- a/boxlang-language/queries.md
+++ b/boxlang-language/queries.md
@@ -4,9 +4,9 @@ description: BoxLang provides the easiest way to query a database
 
 # Queries
 
-CFML became famous in its infancy because it was easy to query databases with a simple `bx:query` tag and no verbose ceremonious coding. There is no ceremony, just a plain datasource definition in the administrator, and we could easily query the database.
+CFML became famous in its infancy because it was easy to query databases with a simple `cfquery` tag and no verbose ceremonious coding. There is no ceremony, just a plain datasource definition in the administrator, and we could easily query the database.
 
-In modern times, we have many more ways to query the database, and defining data sources can occur not only [in our web application's `Application.bx`](datasources.md#defining-datasources-in-applicationbx), but also [globally across the BoxLang runtime via our `boxlang.json` configuration file](datasources.md#defining-datasources-in-boxlangjson), not to mention defining datasources at runtime programmatically or [within the query constructs themselves](datasources.md#defining-inline-datasources).
+In modern times, we obviously have many more ways to query the database. With BoxLang, defining data sources can occur not only [in our web application's `Application.bx`](datasources.md#defining-datasources-in-applicationbx), but also [globally across the BoxLang runtime via our `boxlang.json` configuration file](datasources.md#defining-datasources-in-boxlangjson), not to mention defining datasources at runtime programmatically or [within the query constructs themselves](datasources.md#defining-inline-datasources).
 
 {% hint style="info" %}
 See [Application.bx](../boxlang-framework/applicationbx.md) for more information on how to leverage it for web development.

--- a/boxlang-language/queries.md
+++ b/boxlang-language/queries.md
@@ -64,7 +64,7 @@ The query object can be iterated on like a normal collection through a `for, bx:
 
 {% embed url="https://boxlang.ortusbooks.com/boxlang-language/reference/components/system/loop" %}
 
-**In a CFM Template**
+**In a BXM Template**
 
 ```xml
 <bx:output query = "qItems">

--- a/boxlang-language/variable-scopes.md
+++ b/boxlang-language/variable-scopes.md
@@ -27,7 +27,7 @@ Can be used in any context, used for persisting variables for a period of time.
 * `form` - Variables submitted via HTTP posts
 * `URL` - Variables incoming via HTTP GET operations or the incoming URL
 
-## Template Scopes (CFM)
+## Template Scopes (BXM)
 
 * `variables` - The default or implicit scope where all variables are assigned to.
 


### PR DESCRIPTION
Changed Template Scopes (CFM) in Variable Scopes to Template Scopes (BXM)
Changed "CFML became famous in its infancy because it was easy to query databases with a simple bx:query tag " to "CFML became famous in its infancy because it was easy to query databases with a simple cf:query tag "