### PR TITLE
Edits/2024 11 19

### DIFF
--- a/getting-started/installation/README.md
+++ b/getting-started/installation/README.md
@@ -219,7 +219,7 @@ BoxLang can also run on AWS Lambdas. It even powers our entry playground at [htt
 
 ### CommandBox BoxLang Server
 
-BoxLang can also be deployed using [CommandBox](https://www.ortussolutions.com/products/commandbox). This is our preferred way to deploy web applications using BoxLang. BoxLang +/++ Subscribers even get access to [CommandBox Pro](https://www.ortussolutions.com/products/commandbox-pro). Note: This installation is typically used for web applications which will be served by a CommandNBox server and is not typically used for application which need access to BoxLang from the command line.  
+BoxLang can also be deployed using [CommandBox](https://www.ortussolutions.com/products/commandbox). This is our preferred way to deploy web applications using BoxLang. BoxLang +/++ Subscribers even get access to [CommandBox Pro](https://www.ortussolutions.com/products/commandbox-pro). Note: This installation method is typically localized for a particular web application and is not typically accessed generally by other applications.  
 
 ```bash
 box install commandbox-boxlang

--- a/getting-started/installation/README.md
+++ b/getting-started/installation/README.md
@@ -56,7 +56,7 @@ sudo yum install curl zip unzip java-21-openjdk
 {% endtab %}
 
 {% tab title="Windows" %}
-#### Powershell Script
+### Powershell Script
 
 ```powershell
 # Set the JDK version and download URL
@@ -219,7 +219,7 @@ BoxLang can also run on AWS Lambdas. It even powers our entry playground at [htt
 
 ### CommandBox BoxLang Server
 
-BoxLang can also be deployed using [CommandBox](https://www.ortussolutions.com/products/commandbox). This is our preferred way to deploy web applications using BoxLang. BoxLang +/++ Subscribers even get access to [CommandBox Pro](https://www.ortussolutions.com/products/commandbox-pro).
+BoxLang can also be deployed using [CommandBox](https://www.ortussolutions.com/products/commandbox). This is our preferred way to deploy web applications using BoxLang. BoxLang +/++ Subscribers even get access to [CommandBox Pro](https://www.ortussolutions.com/products/commandbox-pro). Note: This installation is typically used for web applications which will be served by a CommandNBox server and is not typically used for application which need access to BoxLang from the command line.  
 
 ```bash
 box install commandbox-boxlang

--- a/getting-started/running-boxlang/commandbox.md
+++ b/getting-started/running-boxlang/commandbox.md
@@ -165,6 +165,15 @@ Set `env.BOXLANG_DEBUG` in your `server.json` file:
 },
 ```
 
+### `BOXLANG_DEBUG` in a .env file
+
+Set `BOXLANG_DEBUG=true` in a .env file
+
+```bash
+BOXLANG_DEBUG=true
+```
+
+
 ### `.cfconfig.json` `debugMode` setting
 
 Or set `debuggingEnabled` in your `.cfconfig.json` server configuration file:

--- a/getting-started/running-boxlang/commandbox.md
+++ b/getting-started/running-boxlang/commandbox.md
@@ -167,11 +167,11 @@ Set `env.BOXLANG_DEBUG` in your `server.json` file:
 
 ### `.cfconfig.json` `debugMode` setting
 
-Or set `debugMode` in your `.cfconfig.json` server configuration file:
+Or set `debuggingEnabled` in your `.cfconfig.json` server configuration file:
 
 ```json
 {
-    "debugMode" : true
+    "debuggingEnabled" : true
 }
 ```
 

--- a/getting-started/running-boxlang/commandbox.md
+++ b/getting-started/running-boxlang/commandbox.md
@@ -19,7 +19,7 @@ Find out about CommandBox Pro [https://www.ortussolutions.com/products/commandbo
 
 You can find out more about getting started with CommandBox or CommandBox Pro in our [CommandBox documentation](https://commandbox.ortusbooks.com/getting-started-guide).
 
-### Install the Module <a href="#versioning" id="versioning"></a>
+## Install the Module <a href="#versioning" id="versioning"></a>
 
 Once installed, CommandBox needs (for the moment) the `commandbox-boxlang` module to start BoxLang servers. So let's go ahead and install it:
 
@@ -33,7 +33,7 @@ This will add the right file types and handlers to CommandBox for BoxLang.
 This will no longer be needed on CommandBox 6.1+
 {% endhint %}
 
-### Start up a Server
+## Start up a Server
 
 This guide is short and sweet. The hard part has been done. Now, you can start a BoxLang server like any other CommandBox server. So go to the webroot of your choosing and run:
 
@@ -43,21 +43,21 @@ server start cfengine=boxlang javaVersion=openjdk21_jdk
 
 Enjoy your server!
 
-### Server Home
+## Server Home
 
 Like any other CommandBox server, the servers will be stored in your setup's CommandBox Home. The `boxlang.json`, class folders, and modules will all be installed here.
 
-### Installing BoxLang Modules
+## Installing BoxLang Modules
 
 Just like with any server, you can also install modules into the BoxLang server.
 
 ```bash
-install bx-mysql, bx-derby
+install bx-mysql,bx-derby
 ```
 
 That's it. CommandBox knows where to put them and manage them.
 
-### Server.json
+## Server.json
 
 You can also make your CommandBox BoxLang server portable with a `server.json` file:
 
@@ -93,7 +93,7 @@ You can also make your CommandBox BoxLang server portable with a `server.json` f
 }
 ```
 
-### Environment Variables
+## Environment Variables
 
 The servlet/CommandBox runtime uses the same [env variables](./#environment-variables) as the core OS. You can find them here.
 
@@ -101,13 +101,13 @@ The servlet/CommandBox runtime uses the same [env variables](./#environment-vari
 [.](./)
 {% endcontent-ref %}
 
-### Runtime Source Code
+## Runtime Source Code
 
 The runtime source code can be found here: [https://github.com/ortus-boxlang/boxlang-servlet](https://github.com/ortus-boxlang/boxlang-servlet)
 
 We welcome any pull requests, testing, docs, etc.
 
-### Custom boxlang.json
+## Custom boxlang.json
 
 You can use your own custom `boxlang.json` file to startup the engine by using the `app.engineConfigFile` setting in your `server.json`
 
@@ -145,17 +145,17 @@ You can use your own custom `boxlang.json` file to startup the engine by using t
 }
 ```
 
-### Debug Mode
+## Debug Mode
 
 You can set the runtime into debug mode via a few approaches:
 
-#### `--debug` flag via the `server start` command
+### `--debug` flag via the `server start` command
 
 ```bash
 server start --debug
 ```
 
-#### `env.BOXLANG_DEBUG` env variable
+### `env.BOXLANG_DEBUG` env variable
 
 Set `env.BOXLANG_DEBUG` in your `server.json` file:
 
@@ -165,7 +165,7 @@ Set `env.BOXLANG_DEBUG` in your `server.json` file:
 },
 ```
 
-#### `.cfconfig.json` `debugMode` setting
+### `.cfconfig.json` `debugMode` setting
 
 Or set `debugMode` in your `.cfconfig.json` server configuration file:
 
@@ -175,7 +175,6 @@ Or set `debugMode` in your `.cfconfig.json` server configuration file:
 }
 ```
 
-#### Custom `boxlang.json` file
+### Custom `boxlang.json` file
 
 Use the `app.engineConfigFile` to seed a custom `boxlang.json` file into the engine and use the normal settings in the `boxlang.json`.
-


### PR DESCRIPTION
Clarified that CommandBox deployments were usually localized for a particular web application and not generally accesed by other applications (to differntiate from the OS deployment, for example)

Made headers consistent in terms of level 1, level 2 etc and not jumping from level 1 to level 3.

fixed spacing to accurately show `install bx-mysql,bx-derby`