### PR TITLE
Bump link-checker.yml to 3.1.6

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: 'restqa-404-links'
-      uses: restqa/404-links@3.1.4
+      uses: restqa/404-links@3.1.6
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
As per the issue found by @michaelborn on the 404-links checker https://github.com/atalent-labs/404-links/issues/54

The issues has been resolve on the lastest version [3.1.6](https://github.com/atalent-labs/404-links/releases/tag/3.1.6)

This pull request will allow you to use the latest version of the 404-links github actions.


Thank you for your contribution 🙏.