### PR TITLE
Switch to linkspector

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,8 +3,16 @@ name: Linkspector
 on:
   push:
     branches: [ main, v1.x ]
+    paths:
+      - '**/*.md'
   pull_request:
     types: [assigned, opened, synchronize, reopened]
+    paths:
+      - '**/*.md'
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   check-links:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,4 +1,4 @@
-name: Link Checker
+name: Linkspector
 
 on:
   push:
@@ -8,10 +8,14 @@ on:
 
 jobs:
   check-links:
+    name: runner / linkspector
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: 'restqa-404-links'
-      uses: restqa/404-links@3.1.6
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Run linkspector
+        uses: umbrelladocs/action-linkspector@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          fail_level: any
+          filter_mode: added # Show errors only in the added lines (with the + prefix).

--- a/boxlang-framework/jdbc/transactions.md
+++ b/boxlang-framework/jdbc/transactions.md
@@ -127,6 +127,7 @@ BoxLang emits events during the lifecycle of a JDBC transaction which can be use
 * [`onTransactionSetSavepoint`](../interceptors/core-interception-points/transaction-events.md#ontransactionsetsavepoint)
 * [`onTransactionAcquire`](../interceptors/core-interception-points/transaction-events.md#ontransactionacquire)
 * [`onTransactionRelease`](../interceptors/core-interception-points/transaction-events.md#ontransactionrelease)
+* [`TESTING - test linkspector by adding a bad link!`](../interceptors/core-interception-points/bad-link-event.md)
 
 Read more about these events in [transaction events](../interceptors/core-interception-points/transaction-events.md).
 

--- a/boxlang-framework/jdbc/transactions.md
+++ b/boxlang-framework/jdbc/transactions.md
@@ -127,7 +127,6 @@ BoxLang emits events during the lifecycle of a JDBC transaction which can be use
 * [`onTransactionSetSavepoint`](../interceptors/core-interception-points/transaction-events.md#ontransactionsetsavepoint)
 * [`onTransactionAcquire`](../interceptors/core-interception-points/transaction-events.md#ontransactionacquire)
 * [`onTransactionRelease`](../interceptors/core-interception-points/transaction-events.md#ontransactionrelease)
-* [`TESTING - test linkspector by adding a bad link!`](../interceptors/core-interception-points/bad-link-event.md)
 
 Read more about these events in [transaction events](../interceptors/core-interception-points/transaction-events.md).
 
@@ -146,7 +145,7 @@ transaction{
 }
 ```
 
-In Adobe and Lucee, the first query executed within the datasource determines the transactional datasource; that is, the first query to run sets the datasource to use for that transaction. Any queries which specify a different datasource will execute outside the context of the transaction.
+In Adobe and [Lucee Server](https://www.lucee.org/), the first query executed within the datasource determines the transactional datasource; that is, the first query to run sets the datasource to use for that transaction. Any queries which specify a different datasource will execute outside the context of the transaction.
 
 To improve expectations around this behavior, BoxLang supports a `datasource` attribute on the transaction block:
 


### PR DESCRIPTION
Resolves #59 by switching to a link checker tool that supports _only_ checking links present in the diffed (added) markdown lines. This keeps the link checker output relevant, so we can use it as a meaningful quality check, rather than simply more noise.