### PR TITLE
docs: add logger categories to logging guide

### DIFF
--- a/boxlang-framework/logging.md
+++ b/boxlang-framework/logging.md
@@ -20,6 +20,7 @@ BoxLang logging is powered by **Logback** under the hood, which means all of its
 - [Built-In Named Loggers](#built-in-named-loggers)
 - [Configuration Reference](#configuration-reference)
 - [Custom Named Loggers](#custom-named-loggers)
+- [Logger Categories](#logger-categories)
 - [JSON Structured Logging](#json-structured-logging)
 - [LoggingService API](#loggingservice-api)
 - [Logging Interceptors](#logging-interceptors)
@@ -267,6 +268,7 @@ Each named logger under `loggers` supports:
 | `appenderArguments` | `object` | `{}` | Appender-specific key-value configuration. |
 | `encoder` | `string` | `defaultEncoder` | Override the encoder for this logger: `"text"` or `"json"`. |
 | `additive` | `boolean` | `true` | When `true` the logger propagates messages to its parent loggers (including root). Set to `false` to isolate this logger's output. |
+| `categories` | `array` | `[]` | List of Java package or class names whose log output should be routed to this logger. Entries are matched by logger name prefix. Leading/trailing whitespace is trimmed automatically. |
 
 ---
 
@@ -311,6 +313,116 @@ writeLog( text="Admin #adminID# deleted record #recordID#", type="warning", log=
 {% hint style="success" %}
 Setting `"additive": false` on a custom logger stops its messages from also appearing in the root/runtime log, keeping your custom log files clean and focused.
 {% endhint %}
+
+---
+
+## Logger Categories
+
+Logger categories let you route third-party Java library log output into a BoxLang-managed logger. Any Java package or class name listed in a logger's `categories` array will be redirected to that logger — using its configured level and appender — instead of being handled by the default Logback root configuration.
+
+This is especially useful for silencing chatty libraries or capturing their output in a dedicated file.
+
+### How It Works
+
+- Each entry in `categories` is a Java package or class name (e.g. `"com.zaxxer.hikari"`).
+- Log events originating from that package or any sub-package are captured by the target logger.
+- The category logger inherits the target logger's **level** threshold and **appender**.
+- Routing is non-additive: matched events do not bubble up further.
+- Leading/trailing whitespace in category names is trimmed automatically.
+- Loggers with `"level": "OFF"` skip appender creation entirely, making them a zero-overhead sink.
+
+### Routing Noisy Libraries
+
+Configure a dedicated logger to capture (or suppress) output from a specific library:
+
+{% code title="boxlang.json" %}
+```json
+"logging": {
+    "loggers": {
+        "hikari": {
+            "level": "WARN",
+            "appender": "file",
+            "encoder": "text",
+            "additive": false,
+            "categories": [
+                "com.zaxxer.hikari"
+            ]
+        }
+    }
+}
+```
+{% endcode %}
+
+All log events from `com.zaxxer.hikari.*` will now be written to `hikari.log` at `WARN` level or above, and will not appear in `runtime.log`.
+
+### The Built-In Blackhole Logger
+
+BoxLang ships with a pre-configured `blackhole` logger in the default `boxlang.json`. Its level is set to `OFF`, so any categories assigned to it are completely silenced with no I/O overhead:
+
+```json
+"blackhole": {
+    "level": "OFF",
+    "appender": "file",
+    "appenderArguments": {},
+    "encoder": "text",
+    "additive": false,
+    "categories": []
+}
+```
+
+To suppress a noisy library, add its package to the `blackhole` categories list:
+
+```json
+"blackhole": {
+    "level": "OFF",
+    "appender": "file",
+    "appenderArguments": {},
+    "encoder": "text",
+    "additive": false,
+    "categories": [
+        "com.zaxxer.hikari",
+        "org.springframework"
+    ]
+}
+```
+
+{% hint style="warning" %}
+`additive` must be `false` on the blackhole logger (and any silencing logger) to prevent matched events from propagating to the root logger and appearing in `runtime.log`.
+{% endhint %}
+
+### Multiple Categories Across Loggers
+
+You can spread categories across multiple loggers. For example, route database connection pool noise to a dedicated file while silencing framework internals entirely:
+
+{% code title="boxlang.json" %}
+```json
+"logging": {
+    "loggers": {
+        "thirdparty-db": {
+            "level": "WARN",
+            "appender": "file",
+            "encoder": "text",
+            "additive": false,
+            "categories": [
+                "com.zaxxer.hikari",
+                "org.apache.commons.dbcp2"
+            ]
+        },
+        "blackhole": {
+            "level": "OFF",
+            "appender": "file",
+            "appenderArguments": {},
+            "encoder": "text",
+            "additive": false,
+            "categories": [
+                "org.springframework",
+                "io.netty"
+            ]
+        }
+    }
+}
+```
+{% endcode %}
 
 ---
 

--- a/getting-started/configuration/logging.md
+++ b/getting-started/configuration/logging.md
@@ -224,5 +224,45 @@ Each logger will have the following configuration items:
 | **additive** | `true` | `boolean` | **true** means that this logger will inherit the appenders from the root logger and log through all of them. `false` means it doesn't bubble up log messages. |
 | **appender** | `file` | `string` | The type of appender to use for this logger. By default we use the rolling file appender.<br><br>Valid values are:<br>- file<br>- console<br><br>Coming soon values:<br>- smtp<br>- socket<br>- db<br>- syslog<br>- class name |
 | **appenderArguments** | --- | `object` | Name-value pairs that configure the appender. Each appender can have different arguments. |
+| **categories** | `[]` | `array` | A list of Java package or class names whose log output will be routed to this logger. Whitespace is trimmed from each entry. Loggers with `level: OFF` skip appender creation entirely. |
 | **encoder** | `logging > defaultEncoder` | `text` or `json` | The encoder to use for logging. By default it leverages what was defined in the `logging.defaultEncoder` configuration. |
 | **level** | `TRACE` | `logLevel` | The log level is to be assigned to the appender. By default, each appender is wide open to the maximum level of `TRACE`. |
+
+### Logger Categories
+
+The `categories` property lets you redirect third-party Java library log output to a specific BoxLang logger. Any Java package or class name listed in `categories` will have its events captured by that logger at the configured level, with no propagation to parent loggers (non-additive routing).
+
+BoxLang ships with a built-in `blackhole` logger configured at `level: OFF`. Add any noisy library package to its `categories` to silence it completely with zero I/O overhead:
+
+```json
+"blackhole": {
+    "level": "OFF",
+    "appender": "file",
+    "appenderArguments": {},
+    "encoder": "text",
+    "additive": false,
+    "categories": [
+        "com.zaxxer.hikari",
+        "org.springframework"
+    ]
+}
+```
+
+To route library output to a dedicated file instead of suppressing it:
+
+```json
+"thirdparty-db": {
+    "level": "WARN",
+    "appender": "file",
+    "encoder": "text",
+    "additive": false,
+    "categories": [
+        "com.zaxxer.hikari",
+        "org.apache.commons.dbcp2"
+    ]
+}
+```
+
+{% hint style="warning" %}
+Always set `"additive": false` on loggers used for category routing. Otherwise matched events will also propagate up to the root logger.
+{% endhint %}


### PR DESCRIPTION
Documents the new categories feature from ortus-boxlang/BoxLang#511:
- New `categories` logger property routes Java package/class log output to a specific BoxLang logger
- Built-in `blackhole` logger (level OFF) for silencing noisy libraries with zero overhead
- New "Logger Categories" section in the framework logging guide with examples
- Updated logger properties table in both docs files
- Added category routing guidance to the configuration reference

https://claude.ai/code/session_01VaQPFpz3gKa3iwATSjp5FK